### PR TITLE
Update FCSH's defaults.clo file

### DIFF
--- a/LaTeX/unlthesis-files/Schools/unl/fcsh/defaults.clo
+++ b/LaTeX/unlthesis-files/Schools/unl/fcsh/defaults.clo
@@ -137,7 +137,7 @@
 % % Title of Dissertation
 \coveritem[c]{1}{%
   \fontfamily{phv}\fontsize{18}{18}\selectfont%
-  \textcolor{fcshblue}{\textbf{\thetitle}}%
+  \parbox[c][][c]{0.95\stockwidth}{\centering\textcolor{fcshblue}{\textbf{\thetitle}}}
 }
 
 % Author name


### PR DESCRIPTION
fix with big titles so that they leave a small space to the side margins on the cover
