### PR TITLE
Fixing misconfiguration of biblatex setting

### DIFF
--- a/LaTeX/template.tex
+++ b/LaTeX/template.tex
@@ -68,7 +68,7 @@
     %%%%%%%%%%%%%%%%%%%%%%%%%%%%%
     %%% uncomment for 'numeric-by-order-of-citation' like citations
     backend=bibtex,     % use bibtex if possible
-    style=numeric-comp, % numeric(*), alphabetic, authoryear, bwl-FU
+    style=numeric,      % numeric(*), alphabetic, authoryear, bwl-FU
     sortcites=true,     % If numeric, sort cites by crescent order
     sorting=nyt,        % none, nyt(*), ynt
     %%%%%%%%%%%%%%%%%%%%%%%%%%%%%


### PR DESCRIPTION
As described in the issue https://github.com/joaomlourenco/novathesis/issues/71

`template.tex` file had an incorrect setting located in the biblatex settings. The `style` property is incorrectly set to **numeric-comp** instead of **numeric**:
https://github.com/joaomlourenco/novathesis/blob/master/LaTeX/template.tex#L71