### PR TITLE
Added missing "Appendices" translations.

### DIFF
--- a/novathesis-files/fix-babel.clo
+++ b/novathesis-files/fix-babel.clo
@@ -28,16 +28,19 @@
   \def\lstlistingname{Listing}%
   \gdef\annexname{Annex}
   \gdef\annexnamepl{Annexes}
+  \gdef\appendixnamepl{Appendices}
 }
 \addto\captionsfrench{%
   \def\lstlistlistingname{Listes de Code}%
   \gdef\annexname{Annexe}
   \gdef\annexnamepl{Annexes}
+  \gdef\appendixnamepl{Appendices}
 }
 \addto\captionsitalian{%
   \def\lstlistlistingname{Listatos}%
   \gdef\annexname{Annesso}
   \gdef\annexnamepl{Annessi}
+  \gdef\appendixnamepl{Appendici}
 }
 
 


### PR DESCRIPTION
Translations for \appendixnamepl were missing. See example below, with lang=en :

![image](https://user-images.githubusercontent.com/3641060/64187804-29d19600-ce69-11e9-8a3e-3491aae3bdeb.png)

Added translations for English, French and Italian.