### PR TITLE
Add title argument to \ntprintbib

### DIFF
--- a/novathesis.cls
+++ b/novathesis.cls
@@ -1121,11 +1121,11 @@
   \addbibresource{#2}%
 }
 
-\newcommand{\ntprintbib}[1][Bibliography]{%
-    \printbibliography[#1]%
+\newcommand{\ntprintbib}[1][]{%
+  \ifthenelse{\isempty{#1}}%
+  {\printbibliography}%
+  {\printbibliography[title=#1]}%
 }
-
-
 
 %%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%
 %% Copyright page

--- a/novathesis.cls
+++ b/novathesis.cls
@@ -1121,8 +1121,8 @@
   \addbibresource{#2}%
 }
 
-\newcommand{\ntprintbib}{%
-  \printbibliography%
+\newcommand{\ntprintbib}[1][Bibliography]{%
+    \printbibliography[#1]%
 }
 
 


### PR DESCRIPTION
This change enables the user to redefine the bibliography page name.
If no argument is passed, the page will print **Bibliography**

**Context** - My advisor recommended my to replace the **Bibliography** title with **References** and I couldn't find where I could change it.

I reckon another place might be better suited to set this but it was the easiest place to add the change.

An alternative could be:
```latex
\newcommand{\ntprintbib}[1][]{%
  \ifthenelse{\isempty{#1}}%
  {\printbibliography}%
  {\printbibliography[title=#1]}%
}
```
But the submitted one seems to be *much*  simpler