### PR TITLE
Feature/uminho copyright

### DIFF
--- a/Config/1_novathesis.tex
+++ b/Config/1_novathesis.tex
@@ -27,6 +27,8 @@
 %                               %       other/esep, other/mscgt ]
 %                               % DEFAULT: school=nova/fct
 
+\ntsetup{copyrightmodifier=by}
+
 % \ntsetup{langsused=en,pt,de}  % List of languages are used in the document
 %                               %     [ en, pt, fr, it, de, es ]
 %                               % DEFAULT: langsused=en,pt

--- a/NOVAthesisFiles/Schools/uminho/univ-defaults.ldf
+++ b/NOVAthesisFiles/Schools/uminho/univ-defaults.ldf
@@ -93,18 +93,16 @@
 %------------------------------------------------------------------
 
 %%%%%%%%% Important package for the licensing. 
+
+\options{/@nt/langshorttolong=\option{/novathesis/copyrightlang}}
+
+\PassOptionsToPackage{lang=\option{/@nt/langshorttolong}}{doclicense}
+\PassOptionsToPackage{modifier={\option{/novathesis/copyrightmodifier}}}{doclicense}
+
 \RequirePackage[
     type={CC},
-    lang=portuguese,
-    modifier={by-nc-sa},
     version={4.0},
-]{doclicense} % By default english is used, however  is necessary to
-% explicity define the language if the license is in portuguese. The
-% modifier must be changed accordingly to user preferences.  If the
-% licensing is different from any of the Creative Commons (all rights
-% reserved for instance) just uncomment the line with \copyrightfile below
-% and add your own custom file and the doclicense package will be ignored.
-% Here the custom file has the name copyright
+]{doclicense} 
 
 \newcommand{\licenseThis}{%
   \normalsize\textit{\textbf{\theumcopyrightlabel(\option{/novathesis/coverlang})}}\\

--- a/novathesis.cls
+++ b/novathesis.cls
@@ -401,6 +401,8 @@
   , fontstyle=kpfonts        % set kpfonts as the default
   , coverlang/.new choice = {en, pt, fr, it, de, es}
   , copyrightlang/.new choice = {en, pt, fr, it, de, es}
+  , copyrightmodifier/.new choice = {bysa, by, bync, bynd,
+  byncnd, byncsa}
   , lang/.new style = {/novathesis/mainlang=#1,/novathesis/copyrightlang=#1,
                        /novathesis/coverlang=#1}
   , mainlang/.new choice = {en, pt, fr, it, de, es}


### PR DESCRIPTION
- Add the other Creative Commons licenses, namely:
1. CC BY - Attribution
2. CC BY-SA - Attribution, Share-Alike
3. CC BY-NC - Attribution, Non-Commercial
4. CC BY-ND - Attribution, Non-Derivative
5. CC BY-NC-ND - Attribution, Non-Commercial, Non-Derivative

- Change the license language automatically.

NOTE: couldn't put the modifier in format cc-by-sa, given that `doclicense` package gives an error.
```tex
copyrightmodifier/.new choice = {bysa, by, bync, bynd,
   byncnd, byncsa}
```
