### PR TITLE
Fix font size change after copyright

### DIFF
--- a/NOVAthesisFiles/Schools/uminho/univ-defaults.ldf
+++ b/NOVAthesisFiles/Schools/uminho/univ-defaults.ldf
@@ -107,11 +107,12 @@
 % Here the custom file has the name copyright
 
 \newcommand{\licenseThis}{%
-  \normalsize\textit{\textbf{\theumcopyrightlabel(\option{/novathesis/coverlang})}}\\
+  \normalsize%
+  \textit{\textbf{\theumcopyrightlabel(\option{/novathesis/coverlang})}}\\
   \doclicenseImage\\[0.5mm]%
-  \normalsize\textbf{\doclicenseLongName}\\[0.5mm]
-  \normalsize\textbf{\doclicenseName}\\[2ex]
-  \small\url{\doclicenseURL}
+  \textbf{\doclicenseLongName}\\[0.5mm]
+  \textbf{\doclicenseName}\\[2ex]
+  {\small\url{\doclicenseURL}}
 }
 
 \assocarray{umcopyrightlabel}


### PR DESCRIPTION
Fix issue #184, by encapsulating the `\small` macro to only after the URL, as suggested by @joaomlourenco.