### PR TITLE
changed default backend from biber to bibtex

### DIFF
--- a/Config/2_biblatex.tex
+++ b/Config/2_biblatex.tex
@@ -11,9 +11,9 @@
 %%============================================================
 
 %%------------------------------------------------------------
-% If it works, leave biber.  If it fails for you, try bibtex
-\ntbibsetup{backend=biber}
-% \ntbibsetup{backend=bibtex}
+% default bibtex since biber might fail for you.
+\ntbibsetup{backend=bibtex}
+% \ntbibsetup{backend=biber}
 
 %%------------------------------------------------------------
 %% Print only initials of given name


### PR DESCRIPTION
Biber by default (on a macOS environment running vscode with Tex Workshop extension and MacTex backend for Tex) fails the build of this project, by not recognizing any reference or citation. And from the error logs it's next to impossible to find out why the project doesn't build. Not to mention bad user experience if the first time for newbie users building the project fails.

Therefore i would propose bibtex default if it means it will work by default for more users.

( On the other hand, biber backend does work fine on Overleaf, which is what most people use nowadays)