### PR TITLE
[FEAT] Optimise Github Workflow

### DIFF
--- a/.Build/build.sh
+++ b/.Build/build.sh
@@ -1,22 +1,20 @@
 #!/usr/bin/env bash
+set -e
 
-MAKE=$(which gmake)
-[[ -n "$MAKE" ]] || MAKE=make
+MAKE=$(command -v gmake || command -v make)
 
 CONF=Config/1_novathesis.tex
 
-# save the config file
-cp ${CONF} ${CONF}.OLD
-
 # select options for showcase PDF: final phd document form FCT-NOVA, with final index (_índice remissivo_) and trimed book spine
-perl -pi -e "s,.*\\\\ntsetup{doctype=.*},\\\\ntsetup{doctype=phd}," $CONF
-perl -pi -e "s,.*\\\\ntsetup{school=.*},\\\\ntsetup{school=nova/fct}," $CONF
-perl -pi -e "s,.*\\\\ntsetup{docstatus=.*},\\\\ntsetup{docstatus=final}," $CONF
-perl -pi -e "s,.*\\\\ntsetup{spine=.*},\\\\ntsetup{spine=trim}," $CONF
-perl -pi -e "s,.*\\\\ntsetup{printindex=.*},\\\\ntsetup{printindex=true}," $CONF
+sed -i'.OLD' -e 's,.*\\ntsetup{doctype=.*},\\ntsetup{doctype=phd},' \
+            -e 's,.*\\ntsetup{school=.*},\\ntsetup{school=nova/fct},' \
+            -e 's,.*\\ntsetup{docstatus=.*},\\ntsetup{docstatus=final},' \
+            -e 's,.*\\ntsetup{spine=.*},\\ntsetup{spine=trim},' \
+            -e 's,.*\\ntsetup{printindex=.*},\\ntsetup{printindex=true},' \
+            $CONF
 
 # build the PDF
 $MAKE
 
 # restore defaults
-mv ${CONF}.OLD ${CONF}
+mv -f ${CONF}.OLD ${CONF}

--- a/.github/workflows/build-template.yml
+++ b/.github/workflows/build-template.yml
@@ -8,8 +8,6 @@ on:
 
 env:
   VERSION_FILE: NOVAthesisFiles/nt-version.sty
-  ROW_VERSION: 1
-  START_POS_VERSION: 33
   EMAIL_GITHUB: joao.lourenco@fct.unl.pt
   USERNAME_GITHUB: joaomlourenco
 
@@ -21,12 +19,15 @@ jobs:
     if: github.actor != 'my_bot_account'
     steps:
       - name: Checkout the repository
-        uses: actions/checkout@v3.3.0
+        uses: actions/checkout@v3
         with:
-          fetch-depth: 0
           ref: main
           token: ${{ secrets.GITHUB_TOKEN }}
-      - name: Compile the LaTex template
+      - name: Extract version number from nt-version.sty
+        run: |
+          version=$(grep novathesisversion $VERSION_FILE | cut -d "{" -f2 | cut -d "}" -f1)
+          echo "Version number is $version"
+      - name: Compile the LaTeX template
         uses: xu-cheng/texlive-action/full@v1
         with:
           run: bash .Build/build.sh
@@ -39,8 +40,6 @@ jobs:
         run: |
           git config --global user.email "$EMAIL_GITHUB"
           git config --global user.name "$USERNAME_GITHUB"
-          row=$(head -n$ROW_VERSION $VERSION_FILE)
-          version="${row:$START_POS_VERSION:-1}"
           git add -f template.pdf
           git commit -m "Version $version"
           git push


### PR DESCRIPTION
### Few optimisations
Small optimisation for @Dntfreitas's solid work.

### Workflow: `build-template.yml`
- Remove `ROW_VERSION` and `START_POS_VERSION`
- Remove `fetch-depth`and `permissions` parameter in the checkout step, as they are not necessary.

### Build: `build.sh`
- Use `sed` instead of `perl`, it's more efficient and widely available than Perl (also helps with editing directly the backup file with `-i`). 
- Use `set -e` to exit on errors, to ensure that the script will exit if any command fails.
- Use `mv` instead of `cp` and `mv`: Instead of copying the `Config/1_novathesis.tex` file and then moving it back, you can use `mv` to rename it and then rename it back when you're done.
- Modify the `MAKE` variable to use `gmake` if it's available, and fall back to `make` if it's not.