### PR TITLE
[FIX] Workflow version extraction logic

### DIFF
--- a/.github/workflows/build-template.yml
+++ b/.github/workflows/build-template.yml
@@ -25,7 +25,7 @@ jobs:
           token: ${{ secrets.GITHUB_TOKEN }}
       - name: Extract version number from nt-version.sty
         run: |
-          version=$(grep novathesisversion $VERSION_FILE | cut -d "{" -f2 | cut -d "}" -f1)
+          version=$(grep novathesisversion $VERSION_FILE | cut -d "{" -f3 | cut -d "}" -f1)
           echo "Version number is $version"
       - name: Compile the LaTeX template
         uses: xu-cheng/texlive-action/full@v1


### PR DESCRIPTION
I apologize for my oversight on the version extraction logic @Dntfreitas @joaomlourenco  😔

The current [workflow](https://github.com/joaomlourenco/novathesis/actions/runs/4387545127/jobs/7682968257#step:4:1) outputs:
```sh
Version number is
ovathesisversion
```

This fix will result in:
```sh
Version number is 6.10.18
```