### PR TITLE
Fixed typo from "mova" to "nova"

### DIFF
--- a/NOVAthesisFiles/Schools/nova/ims/nova-ims-mgt-defaults.ldf
+++ b/NOVAthesisFiles/Schools/nova/ims/nova-ims-mgt-defaults.ldf
@@ -1,11 +1,11 @@
 %%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%
-%% mova/ims/mova-ims-mgt-defaults.ldf
+%% nova/ims/nova-ims-mgt-defaults.ldf
 %% NOVA thesis configuration file
 %%
 %% Customization for FCT-NOVA (strings and cover)
 %%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%
 
-\typeout{NT FILE mova/ims/mova-ims-mgt-defaults.ldf}%
+\typeout{NT FILE nova/ims/nova-ims-mgt-defaults.ldf}%
 
 \openany
 \ntsetup{print/copyright=false}


### PR DESCRIPTION
Typo "mova" is fixed to "nova" in the header section of the document. I have no idea to what extend this typo affects but it seems like a good thing to be fixed. 

`\ntsetup{school=nova/ims/mgt}` still works as intended without fixing the typo.