### PR TITLE
Added nova/ims/mcsig and nova/ims/mgt to configuration example.

### DIFF
--- a/Config/1_novathesis.tex
+++ b/Config/1_novathesis.tex
@@ -26,7 +26,7 @@
 %                               % DEFAULT: doctype=phd
 
 % \ntsetup{school=uminho/ee}    % The school id
-%                               %     [ nova/fct, nova/fcsh, nova/ims, nova/ensp, nova/itqb,
+%                               %     [ nova/fct, nova/fcsh, nova/ims, nova/ims/mcsig, nova/ims/mgt, nova/ensp, nova/itqb,
 %                               %       ulisboa/ist, ulisboa/fc, ulisboa/fmv,
 %                               %       uminho/ea, uminho/ec, uminho/ed, uminho/ee,
 %                               %       uminho/eeg, uminho/em, uminho/ep, uminho/ese,


### PR DESCRIPTION
School specific configuration options for `mcsig` and `mgt` were left unmentioned under `nova\ims`. Updated the config example options.