### PR TITLE
Create statement-mgt-en.tex

### DIFF
--- a/NOVAthesisFiles/Schools/nova/ims/statement-mgt-en.tex
+++ b/NOVAthesisFiles/Schools/nova/ims/statement-mgt-en.tex
@@ -1,0 +1,42 @@
+%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%
+%% nova/ims/statement-mgt-en.tex
+%% NOVA thesis document file
+%%
+%% Statement
+%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%
+
+\typeout{NT FILE nova/ims/statement-mgt-en.tex}%
+
+\thispagestyle{empty}
+
+%-----------------------------------------------------------------
+% STATEMENT OF INTEGRITY
+%-----------------------------------------------------------------
+\bgroup
+\setlength{\parskip}{1ex plus 1pt minus 1pt}
+\setlength{\parindent}{0cm}
+% \sffamily\footnotesize
+\begin{center}
+  \textbf{STATEMENT OF ORIGINALITY}
+\end{center}
+
+I declare that the work described in this document is my own and not from someone else. All the assistance I have received from other people is duly acknowledged and all the sources (published or unpublished) are referenced.
+
+This work has not been previously evaluated or submitted to \theschool(en) or elsewhere.
+
+\bigskip
+\theschool(en),
+% Accessing /novathesis/examdate/month gives None, currently replaced by \thentdocdate
+\thentdocdate(exam,month,text)
+\thentdocdate(exam,day),
+\thentdocdate(exam,year).\par
+\vspace*{2cm}
+\begin{tabular}{@{}c@{}}
+\toprule
+\thedocauthor(name)
+\end{tabular}
+
+\bigskip
+\emph{The signed original has been archived by the NOVA IMS services.}
+\egroup
+\clearforchapter


### PR DESCRIPTION
No statement document exists for NOVA IMS MGT which gives error upon rendering template. Created one. Accessing /novathesis/examdate/month gives None as output, replaced by \thentdocdate(exam) as a workaround to print out the date.