### PR TITLE
Update nova-ims-mgt-defaults.ldf

### DIFF
--- a/NOVAthesisFiles/Schools/nova/ims/nova-ims-mgt-defaults.ldf
+++ b/NOVAthesisFiles/Schools/nova/ims/nova-ims-mgt-defaults.ldf
@@ -13,7 +13,8 @@
 \ntsetup{lang/cover=en}        % The language for the cover (and second cover) page
 \ntbibsetup{style=authoryear-comp,sortcites=true,sorting=nyt}
 
-\ntdegreename(en){Master of Science in Geospatial Technologies}
+\degreenameprefix(msc,en):={Master of Science in}
+\ntdegreename(en){Geospatial Technologies}
 
 \adviserstring(a,a,en):={Dissertation supervised by:}
 \adviserstring(a,c,en):={Co-supervised by:}
@@ -22,7 +23,7 @@
 \adviserstringfont(c):={\bfseries}
 
 \dissertationstring(msc,en)={Dissertation submitted in partial fulfillment of the requirements\\
-for the degree of \emph{\thedegreename(en)}}
+for the Degree of \emph{\thedegreename(en)}}
 
 
 % University
@@ -33,7 +34,7 @@ for the degree of \emph{\thedegreename(en)}}
 
 % Faculty / School
 \school(pt):={\embrace{NONE}}
-\school(en):={\embrace{NONE}}
+\school(en):={\embrace{NOVA Information Management School}}
 \school(fr):={\embrace{NONE}}
 \school(it):={\embrace{NONE}}
 


### PR DESCRIPTION
Updated degreename and schoolname for correct rendering of front cover and statement pages for NOVA IMS MGT. Currently, it is rendered as "for the degree of Master of Master's in Geospatial Technology" and as NONE in statement page, respectively.

Certain school and program specific configurations such as titles of lists (list of figures, list of tables, etc.) need to be changed into Index of Figures, Index of Tables as well as Bibliographic Referencese instead of Bibliography as according to library service.

Current workaround is by specifying them in fix-babel.tex and modifying novathesis.cls (in case of algorithm list and bibliography titles), but being able to specifying them in school/program specific defaults would be great.