### PR TITLE
ULisboa/IST cover page typo fix

### DIFF
--- a/NOVAthesisFiles/Schools/ulisboa/ist/ulisboa-ist-defaults.ldf
+++ b/NOVAthesisFiles/Schools/ulisboa/ist/ulisboa-ist-defaults.ldf
@@ -15,16 +15,16 @@
 
 \adviserstring(a,1,m,en):={Supervisor}
 \adviserstring(a,1,f,en):={Supervisor}
-\adviserstring(a,2,m,en):={Supervissor}
-\adviserstring(a,2,f,en):={Supervissor}
+\adviserstring(a,2,m,en):={Supervisor}
+\adviserstring(a,2,f,en):={Supervisor}
 \adviserstring(c,1,m,en):={Co-supervisor}
 \adviserstring(c,1,f,en):={Co-supervisor}
-\adviserstring(c,2,m,en):={Co-supervissor}
+\adviserstring(c,2,m,en):={Co-supervisor}
 \adviserstring(c,2,f,en):={Co-supervissor}
 \adviserstring(ca,1,m,en):={Co-supervisor}
 \adviserstring(ca,1,f,en):={Co-supervisor}
-\adviserstring(ca,2,m,en):={Co-supervissor}
-\adviserstring(ca,2,f,en):={Co-supervissor}
+\adviserstring(ca,2,m,en):={Co-supervisor}
+\adviserstring(ca,2,f,en):={Co-supervisor}
 
 \degreestring(bsc,m,en):={BSc}
 \degreestring(bsc,f,en):={BSc}

--- a/NOVAthesisFiles/Schools/ulisboa/ist/ulisboa-ist-defaults.ldf
+++ b/NOVAthesisFiles/Schools/ulisboa/ist/ulisboa-ist-defaults.ldf
@@ -20,7 +20,7 @@
 \adviserstring(c,1,m,en):={Co-supervisor}
 \adviserstring(c,1,f,en):={Co-supervisor}
 \adviserstring(c,2,m,en):={Co-supervisor}
-\adviserstring(c,2,f,en):={Co-supervissor}
+\adviserstring(c,2,f,en):={Co-supervisor}
 \adviserstring(ca,1,m,en):={Co-supervisor}
 \adviserstring(ca,1,f,en):={Co-supervisor}
 \adviserstring(ca,2,m,en):={Co-supervisor}


### PR DESCRIPTION
Currently, the IST cover page has “Supervissor” written in it, instead of “Supervisor”. This pull request fixes that.