### PR TITLE
Fix LaTeX syntax errors in uminho thesis template

### DIFF
--- a/NOVAthesisFiles/Schools/uminho/uminho-defaults.ldf
+++ b/NOVAthesisFiles/Schools/uminho/uminho-defaults.ldf
@@ -207,7 +207,7 @@
 }
 
 % University and School logos
-\ntaddtocover[vspace=-0.6mm,,halign=l,height=2.6cm]{2-1}{%
+\ntaddtocover[vspace=-0.6mm,halign=l,height=2.6cm]{2-1}{%
   \hspace*{-0.5pt}%
   \includegraphics[height=2.5cm]{\theuniversity(logo,GRAY)}%
   \hspace{1pt}%
@@ -236,7 +236,7 @@
 \ntaddtocover[vspace=0.8cm,halign=l,height=5.5cm,valign=t]{1-1,2-1}{%
   \fontsize{17pt}{20.4bp}\selectfont%
   \addfontfeature{LetterSpace=2.9}%
-  \textbf{\thedoctitle(\@LANG@MAIN,main,cover)}
+  \textbf{\thedoctitle(\@LANG@MAIN,main,cover)}%
 }
 
 % Degree info
@@ -260,7 +260,7 @@
 }
 
 % Date
-\ntaddtocover[vspace=1,halign=l]{1-1,2-1}{%
+\ntaddtocover[vspace=1cm,halign=l]{1-1,2-1}{%
   \fontsize{11}{11}\selectfont%
   % \ifdraftdoc
     % \textbf{DRAFT: \today}
@@ -269,13 +269,21 @@
   % \fi
 }
 
+% Empty placeholder for cover position 1-2
+\ntaddtocover[]{1-2}{%
+}
+
+% Empty placeholder for cover position N-1
+\ntaddtocover[]{N-1}{%
+}
+
 
 %%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%
 %% BACK COVER
 %%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%
 
 % Print sponsor logos
-\ntaddtocover[vspace=1, halign=l]{N-2}{%
+\ntaddtocover[vspace=1cm, halign=l]{N-2}{%
   \foreach \myi in {1, ..., 9} {%
     \ifdatadefined{sponsor}(\@LANG@COVER,\myi,logo){%
       \thesponsor(\@LANG@COVER,\myi,logo)\qquad%


### PR DESCRIPTION
## Summary

Fixes critical LaTeX compilation errors in the UMinho thesis template that caused builds to halt and require user interaction.

## Changes Made

- Fixed double comma syntax error in `\ntaddtocover` parameter list
- Added missing comment character after `\thedoctitle` command
- Added missing units to `vspace` parameters: vspace=1 → vspace=1cm
- Added empty cover placeholders for positions 1-2 and N-1 to prevent `\@ntcoverelement@iii` parsing errors

## Testing
- Verified clean compilation with `xelatex -interaction=nonstopmode template.tex`
- Confirmed PDF generation with all covers intact 