### PR TITLE
Update novathesis.cls

### DIFF
--- a/novathesis.cls
+++ b/novathesis.cls
@@ -536,11 +536,10 @@
   \bool_if:NF \g_file_found_bool { #6 }
  }
 
-
-
-
 % Ensure l3regex is available (standard in modern kernels)
-\sys_if_engine_luatex:F { \RequirePackage{l3regex} }
+\usepackage{expl3}
+\expandafter\def\csname ver@l3regex.sty\endcsname{}
+\RequirePackage{l3regex}
 
 \NewDocumentCommand{\IfFileExistsCase}{ s O{} m m }
   {


### PR DESCRIPTION
template.log was giving the error:

```
! LaTeX Error: File `l3regex.sty' not found.

Type X to quit or <RETURN> to proceed,
or enter new name. (Default extension: sty)

Enter file name: 
novathesis.cls:545: Emergency stop.
<read *> 
         
l.545 \NewDocumentCommand
                         {\IfFileExistsCase}{ s O{} m m } 
*** (cannot \read from terminal in nonstop modes)
```

Being the culprit `\sys_if_engine_luatex:F { \RequirePackage{l3regex} }` in the file "novathesis.cls".

This change has solved the issue not only for me but a college of mine with the same error. 

Personally I do not know why it solves it I just copied and pasted from ['l3regex.sty' not found [duplicate]](https://tex.stackexchange.com/questions/479650/l3regex-sty-not-found)