### PR TITLE
fix: Chinese Abstracts Only Supported macOS' CJK font

### DIFF
--- a/1-FrontMatter/abstract-zhs.tex
+++ b/1-FrontMatter/abstract-zhs.tex
@@ -9,9 +9,22 @@
 
 \typeout{NT FILE abstract-zhs.tex}%
 
-% Use a CJK-capable system font (macOS) so Chinese glyphs render.
-\IfFontExistsTF{PingFang SC}{\newfontfamily\ntzhfont{PingFang SC}}{%
-  \IfFontExistsTF{Heiti SC}{\newfontfamily\ntzhfont{Heiti SC}}{\newfontfamily\ntzhfont{Latin Modern Roman}}%
+% Select a CJK font that is likely available in TeX Live (works on Linux/Windows too),
+% with optional fallbacks to common system fonts.
+\IfFontExistsTF{Noto Serif CJK SC}{\newfontfamily\ntzhfont{Noto Serif CJK SC}}{%
+  \IfFontExistsTF{Noto Sans CJK SC}{\newfontfamily\ntzhfont{Noto Sans CJK SC}}{%
+    \IfFontExistsTF{Source Han Serif SC}{\newfontfamily\ntzhfont{Source Han Serif SC}}{%
+      \IfFontExistsTF{Source Han Sans SC}{\newfontfamily\ntzhfont{Source Han Sans SC}}{%
+        \IfFontExistsTF{FandolSong-Regular}{\newfontfamily\ntzhfont{FandolSong-Regular}}{%
+          \IfFontExistsTF{FandolSong}{\newfontfamily\ntzhfont{FandolSong}}{%
+            \IfFontExistsTF{PingFang SC}{\newfontfamily\ntzhfont{PingFang SC}}{%
+              \IfFontExistsTF{Heiti SC}{\newfontfamily\ntzhfont{Heiti SC}}{\newfontfamily\ntzhfont{Latin Modern Roman}}%
+            }%
+          }%
+        }%
+      }%
+    }%
+  }%
 }
 {\ntzhfont
 

--- a/1-FrontMatter/abstract-zht.tex
+++ b/1-FrontMatter/abstract-zht.tex
@@ -9,9 +9,22 @@
 
 \typeout{NT FILE abstract-zht.tex}%
 
-% Use a CJK-capable system font (macOS) so Chinese glyphs render.
-\IfFontExistsTF{PingFang TC}{\newfontfamily\ntzhfont{PingFang TC}}{%
-  \IfFontExistsTF{Heiti TC}{\newfontfamily\ntzhfont{Heiti TC}}{\newfontfamily\ntzhfont{Latin Modern Roman}}%
+% Select a CJK font that is likely available in TeX Live (works on Linux/Windows too),
+% with optional fallbacks to common system fonts.
+\IfFontExistsTF{Noto Serif CJK SC}{\newfontfamily\ntzhfont{Noto Serif CJK SC}}{%
+  \IfFontExistsTF{Noto Sans CJK SC}{\newfontfamily\ntzhfont{Noto Sans CJK SC}}{%
+    \IfFontExistsTF{Source Han Serif SC}{\newfontfamily\ntzhfont{Source Han Serif SC}}{%
+      \IfFontExistsTF{Source Han Sans SC}{\newfontfamily\ntzhfont{Source Han Sans SC}}{%
+        \IfFontExistsTF{FandolSong-Regular}{\newfontfamily\ntzhfont{FandolSong-Regular}}{%
+          \IfFontExistsTF{FandolSong}{\newfontfamily\ntzhfont{FandolSong}}{%
+            \IfFontExistsTF{PingFang SC}{\newfontfamily\ntzhfont{PingFang SC}}{%
+              \IfFontExistsTF{Heiti SC}{\newfontfamily\ntzhfont{Heiti SC}}{\newfontfamily\ntzhfont{Latin Modern Roman}}%
+            }%
+          }%
+        }%
+      }%
+    }%
+  }%
 }
 {\ntzhfont
 


### PR DESCRIPTION
This pull request updates the font selection logic for Chinese text in both the simplified (`abstract-zhs.tex`) and traditional (`abstract-zht.tex`) Chinese abstract files. The new approach prioritizes CJK fonts that are commonly available in TeX Live distributions, improving cross-platform compatibility (Linux/Windows/macOS), and provides a more comprehensive fallback sequence to ensure Chinese glyphs render correctly.

Font selection improvements for Chinese abstracts:

* Updated the font selection in `abstract-zhs.tex` and `abstract-zht.tex` to prioritize TeX Live CJK fonts (`Noto Serif CJK SC`, `Noto Sans CJK SC`, `Source Han Serif SC`, `Source Han Sans SC`, `FandolSong-Regular`, `FandolSong`) before falling back to system fonts (`PingFang SC`, `Heiti SC`, `Latin Modern Roman`). [[1]](diffhunk://#diff-44bcfd15936463aa7fab796a8488412fa924dbd7a874e30608b52ffff9893197L12-R27) [[2]](diffhunk://#diff-4097875887e6ae6c1e89977c6a33f434c188645d8927b6ddef5fe6842fe8fd88L12-R27)
* Ensured that the logic now works reliably across different operating systems by expanding the set of fallback fonts and handling cases where some fonts may not be available. [[1]](diffhunk://#diff-44bcfd15936463aa7fab796a8488412fa924dbd7a874e30608b52ffff9893197L12-R27) [[2]](diffhunk://#diff-4097875887e6ae6c1e89977c6a33f434c188645d8927b6ddef5fe6842fe8fd88L12-R27)